### PR TITLE
Prom keep last point switch

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -300,6 +300,7 @@ type Prometheus struct {
 	ExternalURL                *url.URL      `toml:"-"                             json:"-"`
 	PageTitle                  string        `toml:"page-title"                    json:"page-title"`
 	LookbackDelta              time.Duration `toml:"lookback-delta"                json:"lookback-delta"`
+	KeepLastPoint			   bool          `toml:"keep-last-point"               json:"keep-last-point"               comment:"return the last data point in a series instead of NaN if set"`
 	RemoteReadConcurrencyLimit int           `toml:"remote-read-concurrency-limit" json:"remote-read-concurrency-limit" comment:"concurrently handled remote read requests"`
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -290,6 +290,7 @@ total-timeout = "800ms"
 listen = ":9092"
 external-url = "https://server:3456/uri"
 page-title = "Prometheus Time Series"
+keep-last-point = true
 lookback-delta = "5m"
 
 [debug]
@@ -396,7 +397,14 @@ sample-thereafter = 12
 	assert.Equal(t, expected.Carbonlink, config.Carbonlink)
 
 	// Prometheus
-	expected.Prometheus = Prometheus{Listen: ":9092", ExternalURLRaw: "https://server:3456/uri", PageTitle: "Prometheus Time Series", LookbackDelta: 5 * time.Minute, RemoteReadConcurrencyLimit: 10}
+	expected.Prometheus = Prometheus{
+		Listen: ":9092",
+		ExternalURLRaw: "https://server:3456/uri",
+		PageTitle: "Prometheus Time Series",
+		LookbackDelta: 5 * time.Minute,
+		KeepLastPoint: true,
+		RemoteReadConcurrencyLimit: 10,
+	}
 	u, _ := url.Parse(expected.Prometheus.ExternalURLRaw)
 	expected.Prometheus.ExternalURL = u
 	assert.Equal(t, expected.Prometheus, config.Prometheus)

--- a/doc/config.md
+++ b/doc/config.md
@@ -454,6 +454,8 @@ Only one tag used as filter for index field Tag1, see graphite_tagged table [str
  external-url = ""
  page-title = "Prometheus Time Series Collection and Processing Server"
  lookback-delta = "5m0s"
+ # return the last data point in a series instead of NaN if set
+ keep-last-point = false
  # concurrently handled remote read requests
  remote-read-concurrency-limit = 10
 

--- a/prometheus/querier_select.go
+++ b/prometheus/querier_select.go
@@ -129,7 +129,7 @@ func (q *Querier) Select(ctx context.Context, sortSeries bool, hints *storage.Se
 		return emptySeriesSet() //, nil, nil
 	}
 
-	ss, err := makeSeriesSet(reply[0].Data, step)
+	ss, err := makeSeriesSet(reply[0].Data, step, q.config.Prometheus.KeepLastPoint)
 	if err != nil {
 		return nil // , nil, err @TODO
 	}


### PR DESCRIPTION
Adds an option that allows keeping the last point and outputs it until lookback-delta is reached. 